### PR TITLE
Feature/mobile friendly

### DIFF
--- a/src/canvas.ts
+++ b/src/canvas.ts
@@ -1,10 +1,16 @@
 import { DrawLine } from "./types.js";
 
-const canvas = document.getElementById("mainCanvas") as HTMLCanvasElement;
-const ctx = canvas.getContext("2d");
+let canvas: HTMLCanvasElement | null = null;
+let ctx: CanvasRenderingContext2D | null = null;
+
+const getCanvasContext = (): CanvasRenderingContext2D | null => {
+    if (!canvas) canvas = document.getElementById("mainCanvas") as HTMLCanvasElement;
+    if (!ctx && canvas) ctx = canvas.getContext("2d");
+    return ctx;
+}
 
 export const drawLine = ({ xStart, yStart, xEnd, yEnd }: DrawLine) => {
-    if (!canvas) return;
+    const ctx = getCanvasContext();
     if (!ctx) return;
 
     ctx.beginPath();
@@ -14,14 +20,14 @@ export const drawLine = ({ xStart, yStart, xEnd, yEnd }: DrawLine) => {
 };
 
 export const clearCanvas = () => {
-    if (!canvas) return;
-    if (!ctx) return;
+    const ctx = getCanvasContext();
+    if (!ctx || !canvas) return;
 
     ctx.clearRect(0, 0, canvas.width, canvas.height)
 };
 
 export const ereaseStroke = () => {
-    if (!canvas) return;
+    const ctx = getCanvasContext();
     if (!ctx) return;
 
     ctx.globalCompositeOperation = "destination-out";

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { drawLine, clearCanvas, ereaseStroke } from "./canvas.js";
 import { enableMouseDrawing } from "./mouse.js";
+import { enableTouchDrawing } from "./touch.js";
 import { showColorButtons, showBrushSizes } from "./ui.js";
 
 const initApp = () => {
@@ -12,6 +13,7 @@ const initApp = () => {
     setDrawButton();
     setColorButtons();
     enableMouseDrawing(canvas);
+    enableTouchDrawing(canvas);
 };
 
 const setDrawButton = () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,8 @@ const initApp = () => {
     const canvas = document.getElementById("mainCanvas") as HTMLCanvasElement;
     if (!canvas) { console.log("Canvas not found"); return; };
 
+    setCanvasSize(canvas);
+
     setClearButton();
     setBrushSizes();
     setEreaseStroke();
@@ -14,6 +16,15 @@ const initApp = () => {
     setColorButtons();
     enableMouseDrawing(canvas);
     enableTouchDrawing(canvas);
+};
+
+const setCanvasSize = (canvas: HTMLCanvasElement) => {
+    const container = canvas.parentElement;
+    if (!container) return;
+
+    const containerWidth = container.clientWidth;
+    canvas.width = containerWidth;
+    canvas.height = containerWidth / 2;
 };
 
 const setDrawButton = () => {

--- a/src/mouse.ts
+++ b/src/mouse.ts
@@ -1,19 +1,31 @@
 let isDrawing = false;
 
 export const enableMouseDrawing = (canvas: HTMLCanvasElement) => {
-
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
 
+    const getMousePosition = (e: MouseEvent): { x: number; y: number } => {
+        const canvasRect = canvas.getBoundingClientRect();
+        const scaleX = canvas.width / canvasRect.width;
+        const scaleY = canvas.height / canvasRect.height;
+
+        return {
+            x: (e.clientX - canvasRect.left) * scaleX,
+            y: (e.clientY - canvasRect.top) * scaleY
+        };
+    };
+
     canvas.addEventListener("mousedown", (e) => {
         isDrawing = true;
+        const { x, y } = getMousePosition(e)
         ctx.beginPath();
-        ctx.moveTo(e.offsetX, e.offsetY);
+        ctx.moveTo(x, y);
     });
 
     canvas.addEventListener("mousemove", (e) => {
         if (!isDrawing) return;
-        ctx.lineTo(e.offsetX, e.offsetY);
+        const { x, y } = getMousePosition(e)
+        ctx.lineTo(x, y);
         ctx.stroke();
     });
 

--- a/src/touch.ts
+++ b/src/touch.ts
@@ -1,0 +1,42 @@
+let isDrawing = false;
+
+export const enableTouchDrawing = (canvas: HTMLCanvasElement) => {
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const getTouchPosition = (e: TouchEvent): { x: number; y: number } => {
+        const canvasRect = canvas.getBoundingClientRect();
+        const touch = e.touches[0];
+        return {
+            x: touch.clientX - canvasRect.left,
+            y: touch.clientY - canvasRect.top
+        };
+    };
+
+    canvas.addEventListener("touchstart", (e) => {
+        e.preventDefault();
+        isDrawing = true;
+        const { x, y } = getTouchPosition(e)
+        ctx.beginPath();
+        ctx.moveTo(x, y);
+    }, { passive: false });
+
+    canvas.addEventListener("touchmove", (e) => {
+        e.preventDefault();
+        if (!isDrawing) return;
+        const { x, y } = getTouchPosition(e)
+        ctx.lineTo(x, y);
+        ctx.stroke();
+    }, { passive: false });
+
+    canvas.addEventListener("touchend", (e) => {
+        isDrawing = false;
+        ctx.closePath();
+    });
+
+    canvas.addEventListener("touchcancel", (e) => {
+        isDrawing = false;
+        ctx.closePath();
+    });
+};

--- a/src/touch.ts
+++ b/src/touch.ts
@@ -8,16 +8,18 @@ export const enableTouchDrawing = (canvas: HTMLCanvasElement) => {
     const getTouchPosition = (e: TouchEvent): { x: number; y: number } => {
         const canvasRect = canvas.getBoundingClientRect();
         const touch = e.touches[0];
+        const scaleX = canvas.width / canvasRect.width;
+        const scaleY = canvas.height / canvasRect.height;
         return {
-            x: touch.clientX - canvasRect.left,
-            y: touch.clientY - canvasRect.top
+            x: (touch.clientX - canvasRect.left) * scaleX,
+            y: (touch.clientY - canvasRect.top) * scaleY
         };
     };
 
     canvas.addEventListener("touchstart", (e) => {
         e.preventDefault();
         isDrawing = true;
-        const { x, y } = getTouchPosition(e)
+        const { x, y } = getTouchPosition(e);
         ctx.beginPath();
         ctx.moveTo(x, y);
     }, { passive: false });
@@ -25,7 +27,7 @@ export const enableTouchDrawing = (canvas: HTMLCanvasElement) => {
     canvas.addEventListener("touchmove", (e) => {
         e.preventDefault();
         if (!isDrawing) return;
-        const { x, y } = getTouchPosition(e)
+        const { x, y } = getTouchPosition(e);
         ctx.lineTo(x, y);
         ctx.stroke();
     }, { passive: false });

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -37,7 +37,7 @@ input {
     gap: 10px;
 }
 
-.brush-size {    
+.brush-size {
     width: auto;
     border-radius: 10px;
 }
@@ -50,7 +50,8 @@ button {
     cursor: pointer;
 }
 
-.color-options, .brush-options {
+.color-options,
+.brush-options {
     display: flex;
     flex-flow: row;
     align-items: center;
@@ -65,8 +66,9 @@ button {
     cursor: pointer;
     border: 2px solid black;
 }
+
 .color-swatch {
-    border: none;    
+    border: none;
 }
 
 .color-swatch.active {
@@ -104,4 +106,19 @@ canvas {
     right: -40px;
     z-index: 2;
     pointer-events: none;
+}
+
+.pond-img {
+    height: 50px;
+    position: absolute;
+    bottom: -15px;
+    right: -40px;
+    z-index: 2;
+    pointer-events: none;
+}
+
+@media (max-width: 37em) {
+    canvas {
+        width: 100%;
+    }
 }


### PR DESCRIPTION
- Added touch event listener and now it can be used on mobile :D
- Added a canvas context so its size is always fixed to the css size. This way, I can styles using css and use media queries without breaking the canvas.
- It's also important for touch/tap on mobile, because it takes into account the difference between the canvas and the touch screen.
- Added  setCanvasSize to main so the canvas that feeds the app is already resized for mobile use.
- Added media query for responsiveness.